### PR TITLE
feat: add buffer flush config timer to main config

### DIFF
--- a/src/collector.rs
+++ b/src/collector.rs
@@ -84,7 +84,7 @@ impl Collector {
             service: config.dd.service.clone(),
             host: config.dd.host.clone(),
             port: config.dd.port.clone(),
-            buffer_flush_max_interval: config.dd.buffer_flush_max_interval.clone(),
+            buffer_flush_max_interval: config.dd.buffer_flush_max_interval,
             ..Default::default()
         };
         Self {

--- a/src/config.rs
+++ b/src/config.rs
@@ -11,7 +11,7 @@ pub struct Dd {
     pub host: String,
     #[serde(default = "default_port")]
     pub port: String,
-    #[serde(default= "deafult_buffer_flush_max_interval")]
+    #[serde(default= "default_buffer_flush_max_interval")]
     pub buffer_flush_max_interval: Duration,
 }
 
@@ -68,6 +68,6 @@ fn default_sample_rate() -> f32 {
     1f32
 }
 
-fn deafult_buffer_flush_max_interval() -> Duration {
+fn default_buffer_flush_max_interval() -> Duration {
     Duration::from_millis(200)
 }


### PR DESCRIPTION
Enable how often the buffer is flushed to Datadog
Especially important when doing local development which may incur a
great cost of data
[link to docs](https://docs.rs/datadog-apm/0.2.0/datadog_apm/struct.Config.html#structfield.buffer_flush_max_interval)